### PR TITLE
Add additional tool and input path

### DIFF
--- a/langchain/agents/chat/base.py
+++ b/langchain/agents/chat/base.py
@@ -46,6 +46,10 @@ class ChatAgent(Agent):
     def _extract_tool_and_input(self, text: str) -> Optional[Tuple[str, str]]:
         if FINAL_ANSWER_ACTION in text:
             return "Final Answer", text.split(FINAL_ANSWER_ACTION)[-1].strip()
+
+        if f"{self.llm_prefix} Do I need to use a tool? No" in text:  # Check if the Thought prefix is present
+            return "Final Answer", text.split(FINAL_ANSWER_ACTION)[-1].strip()  # Return the thought text as Final Answer
+
         try:
             _, action, _ = text.split("```")
             response = json.loads(action.strip())
@@ -53,6 +57,7 @@ class ChatAgent(Agent):
 
         except Exception:
             raise ValueError(f"Could not parse LLM output: {text}")
+
 
     @property
     def _stop(self) -> List[str]:


### PR DESCRIPTION
A regular error I encounter is related to the `try`, `except` clause in `_extract_tool_and_input`. I've observed this happening when the LLM can answer the question with the information it has been provided but does not flag it as the Final Answer. I've attempted lowering temperature and using less intelligent models (e.g. `gpt-3.5-turbo` vs. `gpt-4`)

Example Error:

```
 raise ValueError(f"Could not parse LLM output: `{llm_output}`")
ValueError: Could not parse LLM output: `Thought: Do I need to use a tool? No

The small worlds clustering thinking is a concept in network theory that describes the...
```