### PR TITLE
Update conversational for cannot parse llm output

### DIFF
--- a/langchain/agents/conversational/base.py
+++ b/langchain/agents/conversational/base.py
@@ -82,6 +82,8 @@ class ConversationalAgent(Agent):
         regex = r"Action: (.*?)[\n]*Action Input: (.*)"
         match = re.search(regex, llm_output)
         if not match:
+            if f"{self.llm_prefix} Do I need to use a tool? No" in llm_output:
+                return f"{self.ai_prefix} Do I have the final answer? Yes. {llm_output.split(f'Do I need to use a tool? No')[-1].strip()}"
             raise ValueError(f"Could not parse LLM output: `{llm_output}`")
         action = match.group(1)
         action_input = match.group(2)


### PR DESCRIPTION
It's not clear if this return will simply add other problems, but attempting to fix chains where the LLM outputs a thought with an answer and no 'Final Answer'.